### PR TITLE
add test Match types

### DIFF
--- a/editor/initial_code/python_27
+++ b/editor/initial_code/python_27
@@ -5,6 +5,7 @@ def checkio(data):
 
 #These "asserts" using only for self-checking and not necessary for auto-testing
 if __name__ == '__main__':
+    assert isinstance(checkio([[0]]).pop(), list) is True, "Match types"
     assert checkio([[1, 2, 3],
                     [4, 5, 6],
                     [7, 8, 9]]) == [[1, 4, 7],

--- a/editor/initial_code/python_3
+++ b/editor/initial_code/python_3
@@ -5,6 +5,7 @@ def checkio(data):
 
 #These "asserts" using only for self-checking and not necessary for auto-testing
 if __name__ == '__main__':
+    assert isinstance(checkio([[0]]).pop(), list) is True, "Match types"
     assert checkio([[1, 2, 3],
                     [4, 5, 6],
                     [7, 8, 9]]) == [[1, 4, 7],


### PR DESCRIPTION
Интересный баг/фича.

Локальный интерпретатор ругается на решение:
checkio = lambda d: zip(*d)
Но при отправке проверяющей системе она её проглатывает, но выдает assert, хотя задание решено.
Вот так https://yadi.sk/i/FZk13tHMf5h6L

Причина понятна:
Вызов checkio([[1, 2, 3], [4, 5, 6], [7, 8, 9]]) == [(1, 4, 7), (2, 5, 8), (3, 6, 9)]
И вероятно где-то внутри типы преобразуются и ответ верен, но это ведь не так.

Поэтому предлагаю добавить тест:
assert isinstance(checkio([[0]]).pop(), list) is True, "Match types"
Может и не в таком виде, но проверить типы выходных данных стоит.
Чтобы решение прошло только в виде с преобразованными типами: https://yadi.sk/i/rXjhHiOwf5j5D

Не придумал способ, как добавить такой тест в внутренние тесты.
